### PR TITLE
Default to generate one graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ demo/*
 ignore
 ignore/*
 src/test
+src/test.exe
 src/querytranslate/test
 src/queryinterface/test
 

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -20,7 +20,11 @@ int parse_config(const string & filename, config::config & conf) {
     pugi::xml_node root = doc.child("generator");
 
     if (conf.nb_graphs == 0) {
-    	conf.nb_graphs = root.child("size").text().as_uint();
+    	if (root.child("size")) {
+    	    conf.nb_graphs = root.child("size").text().as_uint();
+    	} else {
+    	    conf.nb_graphs = 1;
+    	}
     }
 //    pugi::xml_node graph_node = root.child("graph");
 


### PR DESCRIPTION
The following message is shown when the ``<size></size>``-tag is missing in the config file.
```
Number of graphs is greater than specified by the size
Segmentation fault (core dumped)
```

Only ``test.xml`` in the ``use-cases`` directory contains this tag. 
```
<generator>
	<size>3</size>
	<graph>
		<nodes>10000</nodes>
	</graph>
	<graph>
		<nodes>20000</nodes>
	</graph>
	<graph>
		<nodes>30000</nodes>
	</graph>
...
```

For example ``social-network.xml`` does not contain this tag
```
<generator>
	<graph>
		<nodes>100000</nodes>
	</graph>
...
```




With this pr: the generation of ``1``graph is assumed when the ``<size></size>``-tag is missing.