### PR TITLE
Add time.cpp in the Makefile and add Powershell scripts for Windows support

### DIFF
--- a/demo/scripts_win/clean-play.ps1
+++ b/demo/scripts_win/clean-play.ps1
@@ -1,0 +1,23 @@
+param()
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location demo/play
+
+    
+
+    Remove-Item play*txt
+    Remove-Item *html
+    Remove-Item *xml
+    Remove-Item play-interface/query*
+    Remove-Item play-translated/query*
+    
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/compile-all.ps1
+++ b/demo/scripts_win/compile-all.ps1
@@ -1,0 +1,37 @@
+param(
+    [switch]
+    $CleanBefore
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    if ($CleanBefore) {
+        make "clean"
+    }
+
+    make
+
+    Set-Location querytranslate
+
+    if ($CleanBefore) {
+        make "clean"
+    }
+    make
+
+    Set-Location ../queryinterface
+
+    if ($CleanBefore) {
+        make "clean"
+    }
+    make
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/play.ps1
+++ b/demo/scripts_win/play.ps1
@@ -1,0 +1,22 @@
+param()
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/test.xml -g ../demo/play/play-graph.txt -w ../demo/play/play-workload.xml -r ../demo/play/
+
+    Set-Location querytranslate
+    ./test -w ../../demo/play/play-workload.xml -o ../../demo/play/play-translated
+
+    Set-Location ../queryinterface
+    ./test -w ../../demo/play/play-workload.xml -t ../../demo/play/play-translated -o ../../demo/play/play-interface
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/shop-a.ps1
+++ b/demo/scripts_win/shop-a.ps1
@@ -1,0 +1,25 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/shop-a"
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/shop.xml -g "$folder/shop-a-graph.txt" -w "$folder/shop-a-workload.xml" -r "$folder/" -a
+
+    Set-Location querytranslate
+    ./test -w "$folder/shop-a-workload.xml" -o "$folder/shop-a-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/shop-a-workload.xml" -t "$folder/shop-a-translated" -o "$folder/shop-a-interface"
+
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/shop.ps1
+++ b/demo/scripts_win/shop.ps1
@@ -1,0 +1,25 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/shop"
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/shop.xml -g "$folder/shop-graph.txt" -w "$folder/shop-workload.xml" -r "$folder/"
+
+    Set-Location querytranslate
+    ./test -w "$folder/shop-workload.xml" -o "$folder/shop-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/shop-workload.xml" -t "$folder/shop-translated" -o "$folder/shop-interface"
+
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/social-a.ps1
+++ b/demo/scripts_win/social-a.ps1
@@ -1,0 +1,24 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/social-a"
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/social-network.xml -g "$folder/social-a-graph.txt" -w "$folder/social-a-workload.xml" -r "$folder/" -a
+
+    Set-Location querytranslate
+    ./test -w "$folder/social-a-workload.xml" -o "$folder/social-a-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/social-a-workload.xml" -t "$folder/social-a-translated" -o "$folder/social-a-interface"
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/social.ps1
+++ b/demo/scripts_win/social.ps1
@@ -1,0 +1,24 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/social"
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/social-network.xml -g "$folder/social-graph.txt" -w "$folder/social-workload.xml" -r "$folder/"
+
+    Set-Location querytranslate
+    ./test -w "$folder/social-workload.xml" -o "$folder/social-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/social-workload.xml" -t "$folder/social-translated" -o "$folder/social-interface"
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/test-a.ps1
+++ b/demo/scripts_win/test-a.ps1
@@ -1,0 +1,25 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/test-a/"
+)
+
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+    
+    ./test -c ../use-cases/test.xml -g "$folder/test-a-graph.txt" -w "$folder/test-a-workload.xml" -r "$folder/" -a
+
+    cd querytranslate
+    ./test -w "$folder/test-a-workload.xml" -o "$folder/test-a-translated"
+
+    cd ../queryinterface
+    ./test -w "$folder/test-a-workload.xml" -t "$folder/test-a-translated" -o "$folder/test-a-interface"
+
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/test.ps1
+++ b/demo/scripts_win/test.ps1
@@ -1,0 +1,24 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/test"
+)
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/test.xml -g "$folder/test-graph.txt" -w "$folder/test-workload.xml" -r "$folder/"
+
+    Set-Location querytranslate
+    ./test -w "$folder/test-workload.xml" -o "$folder/test-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/test-workload.xml" -t "$folder/test-translated" -o "$folder/test-interface"
+
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/uniprot-a.ps1
+++ b/demo/scripts_win/uniprot-a.ps1
@@ -1,0 +1,23 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/uniprot-a"
+)
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/uniprot.xml -g "$folder/uniprot-a-graph.txt" -w "$folder/uniprot-a-workload.xml" -r "$folder/" -a
+
+    Set-Location querytranslate
+    ./test -w "$folder/uniprot-a-workload.xml" -o "$folder/uniprot-a-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/uniprot-a-workload.xml" -t "$folder/uniprot-a-translated" -o "$folder/uniprot-a-interface"
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/demo/scripts_win/uniprot.ps1
+++ b/demo/scripts_win/uniprot.ps1
@@ -1,0 +1,24 @@
+param(
+    $Folder = "$((Get-Item $PSScriptRoot).Parent.Fullname)/uniprot"
+)
+
+$prevPwd = $PWD
+
+try {
+    $base = (Get-Item $PSScriptRoot).parent.parent
+    Set-Location ($base.Fullname)
+    
+    Set-Location src
+
+    ./test -c ../use-cases/uniprot.xml -g "$folder/uniprot-graph.txt" -w "$folder/uniprot-workload.xml" -r "$folder/"
+
+    Set-Location querytranslate
+    ./test -w "$folder/uniprot-workload.xml" -o "$folder/uniprot-translated"
+
+    Set-Location ../queryinterface
+    ./test -w "$folder/uniprot-workload.xml" -t "$folder/uniprot-translated" -o "$folder/uniprot-interface"
+
+}
+finally {
+    $prevPwd | Set-Location
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 CC=g++
 CFLAGS=-g -Wall -std=c++11 -I ../libs
 
-objects = test.o gmark.o configparser.o pugixml.o argparse.o randomgen.o config.o workload.o workload2.o \
+objects = test.o gmark.o time.o configparser.o pugixml.o argparse.o randomgen.o config.o workload.o workload2.o \
 			incrementalDeterministicGraphGenerator.o graphNode.o cumulativeDistributionUtils.o \
 			nodeGenerator.o processingEdgeTypes.o correlation.o shiftingDegreeDistribution.o
 
@@ -19,6 +19,9 @@ config.o: config.cpp config.h randomgen.h
 
 gmark.o: gmark.cpp gmark.h config.h randomgen.h
 	$(CC) $(CFLAGS) -c gmark.cpp
+
+time.o:
+	$(CC) $(CFLAGS) -c time.cpp
 
 workload.o: workload.cpp workload.h config.h randomgen.h
 	$(CC) $(CFLAGS) -c workload.cpp


### PR DESCRIPTION
Hello! When I'm trying to compile on Windows I get this error:

```
g++ test.o gmark.o configparser.o pugixml.o argparse.o randomgen.o config.o workload.o workload2.o incrementalDeterministicGraphGenerator.o graphNode.o cumulativeDistributionUtils.o nodeGenerator.o processingEdgeTypes.o correlation.o shiftingDegreeDistribution.o -o test
c:/users/wilat/scoop/apps/gcc/current/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: gmark.o: in function `graph::abstract_graph_writer::build_graph(config::config&, report::report&, int)':
C:\Users\wilat\workspace\gmark\src/gmark.cpp:114: undefined reference to `gettimeofday(timeval*, timezone*)'
c:/users/wilat/scoop/apps/gcc/current/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\wilat\workspace\gmark\src/gmark.cpp:157: undefined reference to `gettimeofday(timeval*, timezone*)'
c:/users/wilat/scoop/apps/gcc/current/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: workload2.o: in function `workload2::generate_workload(config::config const&, workload::workload&, report::workload_report&)':
C:\Users\wilat\workspace\gmark\src/workload2.cpp:869: undefined reference to `gettimeofday(timeval*, timezone*)'
c:/users/wilat/scoop/apps/gcc/current/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\wilat\workspace\gmark\src/workload2.cpp:972: undefined reference to `gettimeofday(timeval*, timezone*)'
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile:12: test] Error 1
```

It's because the `gettimeofday(...)` function is implemented in the time.cpp file, but it is not present in the Makefile

In this PR I've added time.cpp in the Makefile and I also added the equivalent bash scripts in Powershell (Windows' default shell), but I can reset it to remove this commit if you don't want it.